### PR TITLE
Enable sticky footer

### DIFF
--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -3,8 +3,11 @@
 </script>
 
 <footer class="footer">
-	<div class="content has-text-centered">
-		<p>
+	<div
+		class="content has-text-centered is-flex is-justify-content-center is-align-items-center"
+		style="height: 100%;"
+	>
+		<p class="is-align-self-center is-fullwidth">
 			<strong>CommonThread</strong> is an
 			<a href="https://github.com/uchicago-capp-30320/CommonThread">
 				open source project
@@ -26,7 +29,10 @@
 		filter: alpha(opacity=60);
 		width: 100%;
 		padding: 10px;
-		height: 5vh;
+		height: 8vh;
+		max-height: 75px;
+		min-height: 50px;
+		margin: auto;
 	}
 
 	p {

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -25,7 +25,8 @@
 		background-color: var(--gray);
 		filter: alpha(opacity=60);
 		width: 100%;
-		padding: 20px;
+		padding: 10px;
+		height: 5vh;
 	}
 
 	p {

--- a/frontend/src/lib/components/Header.svelte
+++ b/frontend/src/lib/components/Header.svelte
@@ -173,6 +173,7 @@
 		padding: 1rem 2rem;
 		background-color: white;
 		border-bottom: 1px solid #e0e0e0;
+		height: 10vh;
 	}
 
 	.right-section {

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -7,8 +7,44 @@
 	let { children } = $props();
 </script>
 
-<Header />
+<!-- 
+Add full page wrapper and article element to enable sticky footer
+Ref: https://stackoverflow.com/questions/12239166/footer-at-bottom-of-page-or-content-whichever-is-lower
+  -->
 
-{@render children()}
+<div id="main-wrapper">
+	<Header />
+	<article>
+		{@render children()}
+	</article>
+	<Footer />
+</div>
 
-<Footer />
+
+<style>
+	:global(html), :global(body) {
+		height: 100%;
+		margin: 0;
+		padding: 0;
+	}
+
+	#main-wrapper {
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+		-ms-flex-direction: column;
+			flex-direction: column;
+	min-height: 100%;
+	height: auto;
+	height: 100%;
+	margin: 0 auto -142px; /* the bottom margin is the negative value of the footer's height */
+	}
+
+	article {
+		-webkit-box-flex: 1;
+		-ms-flex: 1;
+		flex: 1;
+			}
+</style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -20,31 +20,31 @@ Ref: https://stackoverflow.com/questions/12239166/footer-at-bottom-of-page-or-co
 	<Footer />
 </div>
 
-
 <style>
-	:global(html), :global(body) {
+	:global(html),
+	:global(body) {
 		height: 100%;
 		margin: 0;
 		padding: 0;
 	}
 
 	#main-wrapper {
-	display: -webkit-box;
-	display: -ms-flexbox;
-	display: flex;
-	-webkit-box-orient: vertical;
-	-webkit-box-direction: normal;
+		display: -webkit-box;
+		display: -ms-flexbox;
+		display: flex;
+		-webkit-box-orient: vertical;
+		-webkit-box-direction: normal;
 		-ms-flex-direction: column;
-			flex-direction: column;
-	min-height: 100%;
-	height: auto;
-	height: 100%;
-	margin: 0 auto -142px; /* the bottom margin is the negative value of the footer's height */
+		flex-direction: column;
+		min-height: 100%;
+		height: auto;
+		height: 100%;
+		margin: 0 auto -142px; /* the bottom margin is the negative value of the footer's height */
 	}
 
 	article {
 		-webkit-box-flex: 1;
 		-ms-flex: 1;
 		flex: 1;
-			}
+	}
 </style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -46,7 +46,11 @@
 
 <style>
 	.banner {
-		height: 600px;
+		/* height: 600px;
+		z-index: -1;
+		position: relative;
+		overflow: hidden; */
+		height: 85vh; /*vw 	Relative to 1% of the width of the viewport*/
 		z-index: -1;
 		position: relative;
 		overflow: hidden;


### PR DESCRIPTION
Changed `css` settings to enable sticky footer. This avoid having a floating footer when a page's content doesn't fill a screen. Now, the footer depends on what is lower: the screen or the page content. 

The new change made the landing page had some unused whites pace between the texture image and the footer. To fix this, I changed the heights of the hero image, header, footer to be proportional to the screen height. 